### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unity-meta-file-check.yml
+++ b/.github/workflows/unity-meta-file-check.yml
@@ -12,6 +12,9 @@ on:
       - src/Radio.Unity/Packages/**
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   meta-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AndanteTribe/Radio/security/code-scanning/2](https://github.com/AndanteTribe/Radio/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/unity-meta-file-check.yml` at the workflow root (top level), so it applies to all jobs unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read`

This preserves existing behavior (checkout and read-based checks) while preventing accidental write-capable token usage. No imports, methods, or extra definitions are needed—just YAML configuration update near the top of the file, after `on:` (or before `jobs:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
